### PR TITLE
Update node versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
+  - "6"
+  - "7"
 before_script:
   - npm install -g grunt-cli
 after_success: 'npm run coveralls'


### PR DESCRIPTION
This updates the versions of node that Travis will test against, now that `0.12` is no longer supported.  The versions this now tests are 4 and 6 (both in LTS), as well as 7 (current latest).