### PR TITLE
Do not require global `grunt-cli` installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
   - "0.12"
-before_script:
-  - npm install -g grunt-cli
 after_success: 'npm run coveralls'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "coveralls": "^2.11.2",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-eslint": "^5.1.0",
     "grunt-jasmine-npm": "^0.2.1",
     "istanbul": "^0.3.17"


### PR DESCRIPTION
I had a hard time getting the tests to run locally, until I realized that this package expects a global installation of `grunt-cli`.  It is typically considered an anti-pattern to require global installations, so this PR adds `grunt-cli` to the `devDependencies` and removes the global installation from the travis config.

Now, a simple `npm install && npm test` or `yarn install && yarn test` will complete successfully instead of erroring.